### PR TITLE
Add example test for mounted endpoints & versioning.

### DIFF
--- a/maru_version/mix.exs
+++ b/maru_version/mix.exs
@@ -13,6 +13,6 @@ defmodule MaruVersion.Mixfile do
   end
 
   defp deps do
-    [ {:maru, "~> 0.10"} ]
+    [ {:maru, "~> 0.11"} ]
   end
 end

--- a/maru_version/mix.lock
+++ b/maru_version/mix.lock
@@ -1,6 +1,7 @@
-%{"cowboy": {:hex, :cowboy, "1.0.4", "a324a8df9f2316c833a470d918aaf73ae894278b8aa6226ce7a9bf699388f878", [:rebar, :make], [{:cowlib, "~> 1.0.0", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.0", [hex: :ranch, optional: false]}]},
+%{"cowboy": {:hex, :cowboy, "1.1.2", "61ac29ea970389a88eca5a65601460162d370a70018afe6f949a29dca91f3bb0", [:rebar3], [{:cowlib, "~> 1.0.2", [hex: :cowlib, optional: false]}, {:ranch, "~> 1.3.2", [hex: :ranch, optional: false]}]},
   "cowlib": {:hex, :cowlib, "1.0.2", "9d769a1d062c9c3ac753096f868ca121e2730b9a377de23dec0f7e08b1df84ee", [:make], []},
-  "maru": {:hex, :maru, "0.10.0", "fef6bb9eca9f7a54aea9227d5e8a2a114f720704dcc8caad1cb7cd3917dea405", [:mix], [{:poison, "~> 1.5 or ~> 2.0", [hex: :poison, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:cowboy, "~> 1.0", [hex: :cowboy, optional: false]}]},
-  "plug": {:hex, :plug, "1.1.5", "de5645c18170415a72b18cc3d215c05321ddecac27a15acb923742156e98278b", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: true]}]},
-  "poison": {:hex, :poison, "2.1.0", "f583218ced822675e484648fa26c933d621373f01c6c76bd00005d7bd4b82e27", [:mix], []},
-  "ranch": {:hex, :ranch, "1.2.1", "a6fb992c10f2187b46ffd17ce398ddf8a54f691b81768f9ef5f461ea7e28c762", [:make], []}}
+  "maru": {:hex, :maru, "0.11.3", "0bf2f26955430c4878dab91fe44aeb8b3aaed338b4f6ffd0729ea119284c374d", [:mix], [{:cowboy, "~> 1.0", [hex: :cowboy, optional: false]}, {:plug, "~> 1.0", [hex: :plug, optional: false]}, {:poison, "~> 1.5 or ~> 2.0 or ~> 3.0", [hex: :poison, optional: false]}]},
+  "mime": {:hex, :mime, "1.1.0", "01c1d6f4083d8aa5c7b8c246ade95139620ef8effb009edde934e0ec3b28090a", [:mix], []},
+  "plug": {:hex, :plug, "1.3.3", "d9be189924379b4e9d470caef87380d09549aea1ceafe6a0d41292c8c317c923", [:mix], [{:cowboy, "~> 1.0.1 or ~> 1.1", [hex: :cowboy, optional: true]}, {:mime, "~> 1.0", [hex: :mime, optional: false]}]},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], []},
+  "ranch": {:hex, :ranch, "1.3.2", "e4965a144dc9fbe70e5c077c65e73c57165416a901bd02ea899cfd95aa890986", [:rebar3], []}}

--- a/maru_version/test/test_helper.exs
+++ b/maru_version/test/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+Maru.Test.start()

--- a/maru_version/test/version_test.exs
+++ b/maru_version/test/version_test.exs
@@ -5,3 +5,16 @@ defmodule VersionTest do
     assert 1 + 1 == 2
   end
 end
+
+defmodule V1Test do
+  use ExUnit.Case
+  use Maru.Test, for: MaruVersion.API.V1
+
+  test "/" do
+    assert "It works V1!" = get("/", "v1") |> text_response
+  end
+
+  test "/shared" do
+    assert "It works for all version!" = get("/shared", "v1") |> text_response
+  end
+end


### PR DESCRIPTION
@falood This test is currently failing and I’m looking to understand how a test should be written to prove that the shared resource is available at v1. I also upgraded maru to 0.11.3 for this example.